### PR TITLE
Add CODEOWNERS for required owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require review from the repo owner
+* @albingcj


### PR DESCRIPTION
Adds `.github/CODEOWNERS` file that auto-requests @albingcj as reviewer on all PRs.

This ensures the repo owner is always notified and required to review before any merge.