### PR TITLE
test: validate CI pipeline runs on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/src/utils/ci-test.ts
+++ b/src/utils/ci-test.ts
@@ -1,0 +1,7 @@
+// This file intentionally has a lint error to test CI pipeline
+// eslint should catch the unused variable (error-level in strict mode)
+
+export function testCIValidation() {
+  const result = 'CI pipeline is working';
+  return result;
+}


### PR DESCRIPTION
Test PR to validate the CI pipeline runs correctly on pull requests.

This adds a harmless test file. If CI passes (green check), the pipeline is working. We can close this PR after confirming.